### PR TITLE
Fix connection timeout in manual confirm lsn mode

### DIFF
--- a/pg-subscription-stream.js
+++ b/pg-subscription-stream.js
@@ -62,7 +62,9 @@ class PgSubscriptionStream extends Transform {
 			const lsn = chunk.readBigUInt64BE(1)
 			const shouldRespond = chunk.readInt8(1 + 8 + 8)
 			this.output_written_lsn = this.output_written_lsn > lsn ? this.output_written_lsn : lsn
-			this.flush_written_lsn = autoConfirmLSN ? this.output_written_lsn : this.flush_written_lsn
+			if (autoConfirmLSN || this.flush_written_lsn === invalid_lsn) {
+				this.flush_written_lsn = this.output_written_lsn;
+			}
 			this.sendFeedback(shouldRespond > 0)
 		} else {
 			callback(new Error(`Unknown Message: ${chunk}`))


### PR DESCRIPTION
Fixes connection timeout in !autoConfirmLsn mode when there is no transaction on the db for an extended period of time and hence no lsn for the user to set for flushing.